### PR TITLE
limit docker resources

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,11 @@ services:
       default:
         # static IP address for unifi controller
         ipv4_address: 172.16.1.2
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 2048MB
 
 networks:
   default:


### PR DESCRIPTION
Docker compose honors resource limits and reservations like kubernetes. And since Firewalla Golds' are a bit tight on RAM and CPU, adding some conservative limits is helpful, especially during startup. 

See Unifi recommended system requriements [here](https://help.ui.com/hc/en-us/articles/360012282453-Self-Hosting-a-UniFi-Network-Server)